### PR TITLE
[patch] ENGMT-2400: Sets up link shortener demo app

### DIFF
--- a/BranchLinkSimulator.xcodeproj/project.pbxproj
+++ b/BranchLinkSimulator.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3;
+				MARKETING_VERSION = 2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.link-simulator";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -378,7 +378,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.3;
+				MARKETING_VERSION = 2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.link-simulator";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/BranchLinkSimulator/ApiConfiguration.swift
+++ b/BranchLinkSimulator/ApiConfiguration.swift
@@ -16,13 +16,22 @@ struct ApiConfiguration: Identifiable, Codable, Equatable {
     var staging: Bool
 }
 
-let STAGING = "Staging"
-let PRODUCTION = "Production"
-let STAGING_AC = "Staging AC"
-let PRODUCTION_AC = "Production AC"
+let STAGING = "[Stage] External Services"
+let PRODUCTION = "Pro Production"
+let STAGING_AC = "[Stage] Adv. Compliance Sandbox"
+let PRODUCTION_AC = "Adv. Compliance Sandbox"
+let STAGING_LS = "[Stage] LS + ENGMT Ess. Demo"
+let PRODUCTION_LS = "LS + ENGMT Ess. Demo"
 
 
 var apiConfigurationsMap: [String: ApiConfiguration] = [
+    STAGING_LS: ApiConfiguration(
+        name: STAGING_LS,
+        branchKey: "key_live_nFc30jPoTV53LhvHat5XXffntufA4O0l",
+        apiUrl: "https://api.stage.branch.io",
+        appId: "1425582272655938028",
+        staging: true
+    ),
     STAGING_AC: ApiConfiguration(
         name: STAGING_AC,
         branchKey: "key_live_juoZrlpzQZvBQbwR33GO5hicszlTGnVT",
@@ -37,6 +46,13 @@ var apiConfigurationsMap: [String: ApiConfiguration] = [
         appId: "436637608899006753",
         staging: true
     ),
+    PRODUCTION_LS: ApiConfiguration(
+        name: PRODUCTION_LS,
+        branchKey: "key_live_hsdXYiNiH9pfDv50xrFt0gbgEEiMIqFO",
+        apiUrl: "https://api3.branch.io",
+        appId: "1425583205569811094",
+        staging: false
+    ),
     PRODUCTION_AC: ApiConfiguration(
         name: PRODUCTION_AC,
         branchKey: "key_live_hshD4wiPK2sSxfkZqkH30ggmyBfmGmD7",
@@ -46,9 +62,9 @@ var apiConfigurationsMap: [String: ApiConfiguration] = [
     ),
     PRODUCTION: ApiConfiguration(
         name: PRODUCTION,
-        branchKey: "key_live_iDiV7ZewvDm9GIYxUnwdFdmmvrc9m3Aw",
+        branchKey: "key_live_iCh53eMdH5aIibeOqRYBojgpyrmU4gd8",
         apiUrl: "https://api3.branch.io",
-        appId: "1364964166783226677",
+        appId: "1425585005551178435",
         staging: false
     )
 ]

--- a/BranchLinkSimulator/BranchLinkSimulator.entitlements
+++ b/BranchLinkSimulator/BranchLinkSimulator.entitlements
@@ -4,6 +4,18 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:r3dfg-alternate.app.link</string>
+		<string>r3dfg-alternate.app.link</string>
+		<string>applinks:skhsg-alternate.branchbeta.link</string>
+		<string>skhsg-alternate.branchbeta.link</string>
+		<string>applinks:hoplink.branchcustom.xyz</string>
+		<string>hoplink.branchcustom.xyz</string>
+		<string>applinks:r3dfg.app.link</string>
+		<string>r3dfg.app.link</string>
+		<string>applinks:hop.link</string>
+		<string>hop.link</string>
+		<string>skhsg.branchbeta.link</string>
+		<string>applinks:skhsg.branchbeta.link</string>
 		<string>applinks:stage-freedom.branchbeta.link</string>
 		<string>stage-freedom.branchbeta.link</string>
 		<string>applinks:stage-freedom-alternate.branchbeta.link</string>
@@ -20,18 +32,14 @@
 		<string>prod-freedom.app.link</string>
 		<string>applinks:prod-freedom.test.app.link</string>
 		<string>prod-freedom.test.app.link</string>
-		<string>applinks:prod-freedom-prod-alternate.app.link</string>
-		<string>prod-freedom-prod-alternate.app.link</string>
-		<string>applinks:prod-freedom.app.link</string>
+		<string>applinks:prod-freedom-alternate.app.link</string>
+		<string>prod-freedom-alternate.app.link</string>
 		<string>applinks:prod-ac-sandbox.app.link</string>
 		<string>prod-ac-sandbox.app.link</string>
 		<string>applinks:prod-ac-sandbox-alternate.app.link</string>
 		<string>prod-ac-sandbox-alternate.app.link</string>
 		<string>applinks:prod-ac-sandbox-alternate.app.link</string>
 		<string>prod-ac-sandbox.test.app.link</string>
-		<string>applinks:allergics.org</string>
-		<string>linksimulator.branchcustom.xyz</string>
-		<string>applinks:linksimulator.branchcustom.xyz</string>
 	</array>
 </dict>
 </plist>

--- a/BranchLinkSimulator/Info.plist
+++ b/BranchLinkSimulator/Info.plist
@@ -26,19 +26,14 @@
 	</dict>
 	<key>branch_universal_link_domains</key>
 	<array>
-		<string>allergics.org</string>
-		<string>branchlinksimulator.app.link</string>
-		<string>branchlinksimulator-alternate.app.link</string>
-		<string>branchlinksimulator.test.app.link</string>
-		<string>ac-sandbox.branchbeta.link</string>
-		<string>ac-sandbox-alternate.branchbeta.link</string>
-		<string>ac-sandbox.test.branchbeta.link</string>
-		<string>freedom-external-services.branchbeta.link</string>
-		<string>freedom-external-services-alternate.branchbeta.link</string>
-		<string>freedom-external-services.test.branchbeta.link</string>
-		<string>freedom-prod.app.link</string>
-		<string>freedom-prod-alternate.app.link</string>
-		<string>freedom-prod.test.app.link</string>
+		<string>prod-freedom.app.link</string>
+		<string>prod-freedom.branchcustom.xyz</string>
+		<string>stage-freedom.branchcustom.xyz</string>
+		<string>stage-freedom.branchbeta.link</string>
+		<string>skhsg.branchbeta.link</string>
+		<string>r3dfg.app.link</string>
+		<string>hoplink.branchcustom.xyz</string>
+		<string>hop.link</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
We want to configure Link Shortener + Engagement Essentials as a demo app for our client-facing teams.

I added this as an additional environment here, and all domains for app links.

I also removed the Pro + LS app, and replaced it with the regular Pro app in Prod, which will not have Link shortener. In the future this will be used for click testing, and having Link Shortener disabled on one such test app is necessary.

