### PR TITLE
feat(EMT-2878): integrate modern SessionManager with async/await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,16 +23,6 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-<<<<<<< HEAD
-Packages/
-Package.pins
-Package.resolved
-*.xcodeproj
-#
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-.swiftpm
-=======
 # Packages/
 # Package.pins
 # Package.resolved
@@ -41,7 +31,6 @@ Package.resolved
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
 # .swiftpm
->>>>>>> cd22661 (Update)
 
 .build/
 

--- a/BranchLinkSimulator.xcodeproj/project.pbxproj
+++ b/BranchLinkSimulator.xcodeproj/project.pbxproj
@@ -19,9 +19,8 @@
 		C16B97A02B75A0FA00FB0631 /* DeeplinkDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16B979F2B75A0FA00FB0631 /* DeeplinkDetailView.swift */; };
 		C16B97A22B75A18A00FB0631 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16B97A12B75A18A00FB0631 /* AppDelegate.swift */; };
 		C16B97B22B87BD8300FB0631 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C16B97B02B87BD8000FB0631 /* AdSupport.framework */; };
-		E78DBA1F2E9786B1009FE663 /* BranchSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E78DBA1E2E9786B1009FE663 /* BranchSDK.xcframework */; };
-		E78DBA202E9786B1009FE663 /* BranchSDK.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E78DBA1E2E9786B1009FE663 /* BranchSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E7EA36B22DD63A350094FCC9 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7EA36B12DD63A350094FCC9 /* SafariServices.framework */; };
+		F1A2B3C4D5E6F7891ABCDEF1 /* BranchSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F1A2B3C4D5E6F7890ABCDEF0 /* BranchSDK */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,7 +30,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E78DBA202E9786B1009FE663 /* BranchSDK.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -54,7 +52,6 @@
 		C16B97A52B75A4F800FB0631 /* BranchLinkSimulator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BranchLinkSimulator.entitlements; sourceTree = "<group>"; };
 		C16B97A62B75A5F700FB0631 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C16B97B02B87BD8000FB0631 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
-		E78DBA1E2E9786B1009FE663 /* BranchSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = BranchSDK.xcframework; path = Frameworks/BranchSDK.xcframework; sourceTree = "<group>"; };
 		E7EA36B12DD63A350094FCC9 /* SafariServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SafariServices.framework; path = System/Library/Frameworks/SafariServices.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -64,7 +61,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E7EA36B22DD63A350094FCC9 /* SafariServices.framework in Frameworks */,
-				E78DBA1F2E9786B1009FE663 /* BranchSDK.xcframework in Frameworks */,
+				F1A2B3C4D5E6F7891ABCDEF1 /* BranchSDK in Frameworks */,
 				C16B97B22B87BD8300FB0631 /* AdSupport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,7 +117,6 @@
 		C16B97AF2B87BD8000FB0631 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E78DBA1E2E9786B1009FE663 /* BranchSDK.xcframework */,
 				E7EA36B12DD63A350094FCC9 /* SafariServices.framework */,
 				C16B97B02B87BD8000FB0631 /* AdSupport.framework */,
 			);
@@ -145,6 +141,7 @@
 			);
 			name = BranchLinkSimulator;
 			packageProductDependencies = (
+				F1A2B3C4D5E6F7890ABCDEF0 /* BranchSDK */,
 			);
 			productName = BranchLinkSimulator;
 			productReference = C16B978B2B759F9D00FB0631 /* BranchLinkSimulator.app */;
@@ -175,6 +172,7 @@
 			);
 			mainGroup = C16B97822B759F9D00FB0631;
 			packageReferences = (
+				F1A2B3C4D5E6F7890ABCDEF2 /* XCLocalSwiftPackageReference "ios-branch-deep-linking-attribution" */,
 			);
 			productRefGroup = C16B978C2B759F9D00FB0631 /* Products */;
 			projectDirPath = "";
@@ -442,6 +440,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		F1A2B3C4D5E6F7890ABCDEF2 /* XCLocalSwiftPackageReference "ios-branch-deep-linking-attribution" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../ios-branch-deep-linking-attribution";
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F1A2B3C4D5E6F7890ABCDEF0 /* BranchSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BranchSDK;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C16B97832B759F9D00FB0631 /* Project object */;
 }

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -5,8 +5,9 @@
 //  Created by Nipun Singh on 2/8/24.
 //
 
-import SwiftUI
 import BranchSDK
+import BranchSwiftSDK
+import SwiftUI
 
 struct AlertItem: Identifiable {
     var id: String { message }
@@ -17,19 +18,27 @@ class DeepLinkViewModel: ObservableObject {
     @Published var deepLinkHandled = false
     @Published var deepLinkData: [String: AnyObject]? = nil
     @Published var errorItem: AlertItem? = nil
+    @Published var sessionState: String = "Uninitialized"
 }
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var deepLinkViewModel = DeepLinkViewModel()
     var store = RoundTripStore()
-    
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        
+
+    /// Reference to the modern SessionManager via BranchSessionCoordinator
+    private var sessionCoordinator: BranchSessionCoordinator {
+        BranchSessionCoordinator.shared
+    }
+
+    func application(_: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         let config = loadConfigOrDefault()
+
+        // Configure the legacy SDK for API URL and Branch Key
+        // (still needed for network layer configuration)
         Branch.setAPIUrl(config.apiUrl)
         Branch.setBranchKey(config.branchKey)
-        
-        Branch.enableLogging(at: .verbose) { msg, logLevel, err, request, response in
+
+        Branch.enableLogging(at: .verbose) { _, _, _, request, response in
             self.store.processLog(request, response)
         }
 
@@ -38,37 +47,178 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let savedId = UserDefaults.standard.string(forKey: "blsSessionId") {
             blsSessionId = savedId
         } else {
-            // Generate a new UUID if one does not exist
             blsSessionId = UUID().uuidString
             UserDefaults.standard.set(blsSessionId, forKey: "blsSessionId")
         }
-        
+
         // Set the bls_session_id in Branch request metadata
         Branch.getInstance().setRequestMetadataKey("bls_session_id", value: blsSessionId)
 
-        Branch.getInstance().initSession(launchOptions: launchOptions) { (params, error) in
-            print(params as? [String: AnyObject] ?? {})
-            if let error = error {
-                var message = "Failed to initialize Branch SDK: \(error.localizedDescription)."
-                if config.staging {
-                  message += " Are you connected to VPN?"
-                }
-                self.deepLinkViewModel.errorItem = AlertItem(message: message)
-            }
-            if let params = params as? [String: AnyObject] {
-                if let clickedBranchLink = params["+clicked_branch_link"] as? NSNumber, clickedBranchLink.boolValue == true {
-                    DispatchQueue.main.async {
-                        self.deepLinkViewModel.deepLinkData = params
-                        self.deepLinkViewModel.deepLinkHandled = true
-                    }
-                } else {
-                    print("Didn't click Branch link")
-                }
+        // Use the NEW SessionManager for initialization
+        initializeWithModernSessionManager(launchOptions: launchOptions, config: config)
 
-            }
-        }
-        
+        // Start observing session state changes
+        observeSessionState()
+
         return true
     }
-    
+
+    // MARK: - Modern SessionManager Integration
+
+    /// Initialize Branch using the new Swift SessionManager with task coalescing
+    private func initializeWithModernSessionManager(
+        launchOptions: [UIApplication.LaunchOptionsKey: Any]?,
+        config: ApiConfiguration
+    ) {
+        Task {
+            do {
+                // Build initialization options
+                var options = InitializationOptions()
+
+                // Extract URL from launch options if present
+                if let launchURL = launchOptions?[.url] as? URL {
+                    options.url = launchURL
+                }
+
+                // Extract source application if present
+                if let sourceApp = launchOptions?[.sourceApplication] as? String {
+                    options.sourceApplication = sourceApp
+                }
+
+                print("[BranchLinkSimulator] Initializing with modern SessionManager...")
+
+                // Initialize using the new SessionManager
+                let session = try await sessionCoordinator.sessionManager.initialize(options: options)
+
+                print("[BranchLinkSimulator] Session initialized: \(session)")
+
+                // Convert session to params format for UI compatibility
+                await MainActor.run {
+                    handleSessionInitialized(session, config: config)
+                }
+
+            } catch {
+                print("[BranchLinkSimulator] Session initialization failed: \(error)")
+
+                await MainActor.run {
+                    var message = "Failed to initialize Branch SDK: \(error.localizedDescription)."
+                    if config.staging {
+                        message += " Are you connected to VPN?"
+                    }
+                    self.deepLinkViewModel.errorItem = AlertItem(message: message)
+                }
+            }
+        }
+    }
+
+    /// Handle successful session initialization
+    @MainActor
+    private func handleSessionInitialized(_ session: Session, config _: ApiConfiguration) {
+        print("[BranchLinkSimulator] Session ID: \(session.id)")
+        print("[BranchLinkSimulator] Identity ID: \(session.identityId)")
+        print("[BranchLinkSimulator] Is First Session: \(session.isFirstSession)")
+
+        // Check if there's deep link data
+        if let linkData = session.linkData {
+            print("[BranchLinkSimulator] Deep link detected: \(linkData)")
+
+            // Convert to the format expected by the existing UI
+            var params: [String: AnyObject] = [:]
+            params["+clicked_branch_link"] = true as AnyObject
+            params["session_id"] = session.id as AnyObject
+            params["identity_id"] = session.identityId as AnyObject
+            params["+is_first_session"] = session.isFirstSession as AnyObject
+
+            if let url = linkData.url {
+                params["~referring_link"] = url.absoluteString as AnyObject
+            }
+
+            // Add custom parameters from link data
+            for (key, value) in linkData.parameters {
+                params[key] = value.value as AnyObject
+            }
+
+            deepLinkViewModel.deepLinkData = params
+            deepLinkViewModel.deepLinkHandled = true
+        } else {
+            print("[BranchLinkSimulator] No deep link data - organic session")
+        }
+    }
+
+    /// Observe session state changes using the new async stream API
+    private func observeSessionState() {
+        Task {
+            for await state in sessionCoordinator.sessionManager.observeState() {
+                await MainActor.run {
+                    // Use SessionState's built-in description
+                    self.deepLinkViewModel.sessionState = state.description
+                    print("[BranchLinkSimulator] State: \(state.description)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Universal Links (Scene-based apps)
+
+    func application(
+        _: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler _: @escaping ([UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let url = userActivity.webpageURL
+        else {
+            return false
+        }
+
+        print("[BranchLinkSimulator] Received Universal Link: \(url)")
+
+        // Handle via the new SessionManager (task coalescing will merge if initialization is in progress)
+        Task {
+            do {
+                var options = InitializationOptions()
+                options.url = url
+
+                let session = try await sessionCoordinator.sessionManager.initialize(options: options)
+
+                await MainActor.run {
+                    let config = loadConfigOrDefault()
+                    handleSessionInitialized(session, config: config)
+                }
+            } catch {
+                print("[BranchLinkSimulator] Universal Link handling failed: \(error)")
+            }
+        }
+
+        return true
+    }
+
+    // MARK: - URL Scheme Deep Links
+
+    func application(
+        _: UIApplication,
+        open url: URL,
+        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+    ) -> Bool {
+        print("[BranchLinkSimulator] Received URL Scheme: \(url)")
+
+        Task {
+            do {
+                var initOptions = InitializationOptions()
+                initOptions.url = url
+                initOptions.sourceApplication = options[.sourceApplication] as? String
+
+                let session = try await sessionCoordinator.sessionManager.initialize(options: initOptions)
+
+                await MainActor.run {
+                    let config = loadConfigOrDefault()
+                    handleSessionInitialized(session, config: config)
+                }
+            } catch {
+                print("[BranchLinkSimulator] URL Scheme handling failed: \(error)")
+            }
+        }
+
+        return true
+    }
 }

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -67,24 +67,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Modern SessionManager Integration
 
     /// Initialize Branch using the new Swift SessionManager with task coalescing
+    @MainActor
     private func initializeWithModernSessionManager(
         launchOptions: [UIApplication.LaunchOptionsKey: Any]?,
         config: ApiConfiguration
     ) {
         Task {
             do {
-                // Build initialization options
-                var options = InitializationOptions()
-
-                // Extract URL from launch options if present
-                if let launchURL = launchOptions?[.url] as? URL {
-                    options.url = launchURL
-                }
-
-                // Extract source application if present
-                if let sourceApp = launchOptions?[.sourceApplication] as? String {
-                    options.sourceApplication = sourceApp
-                }
+                // Build initialization options using the builder pattern
+                let options = InitializationOptions()
+                    .with(launchOptions: launchOptions)
 
                 print("[BranchLinkSimulator] Initializing with modern SessionManager...")
 
@@ -110,6 +102,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
         }
+    }
+
+    /// Handle session for UI updates (called from BranchLinkSimulatorApp onOpenURL)
+    @MainActor
+    func handleSessionForUI(_ session: Session) {
+        let config = loadConfigOrDefault()
+        handleSessionInitialized(session, config: config)
     }
 
     /// Handle successful session initialization

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -26,6 +26,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var deepLinkViewModel = DeepLinkViewModel()
     var store = RoundTripStore()
 
+    /// Task for observing network logs (keeps the stream alive)
+    private var logObserverTask: Task<Void, Never>?
+
     /// Reference to the modern SessionManager via BranchSessionCoordinator
     private var sessionCoordinator: BranchSessionCoordinator {
         BranchSessionCoordinator.shared
@@ -39,21 +42,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Branch.setAPIUrl(config.apiUrl)
         Branch.setBranchKey(config.branchKey)
 
+        // Legacy SDK logging (for events, links, QR codes)
         Branch.enableLogging(at: .verbose) { _, _, _, request, response in
             self.store.processLog(request, response)
         }
 
-        // Set up logging callback for the new Swift SessionManager network layer
-        DefaultBranchNetworkService.logCallback = { [weak self] url, requestBody, responseBody, statusCode, error in
-            guard let self = self else { return }
-            self.store.processSwiftNetworkLog(
-                url: url,
-                requestBody: requestBody,
-                responseBody: responseBody,
-                statusCode: statusCode,
-                error: error
-            )
-        }
+        // MARK: - Modern AsyncStream Logging (Swift Concurrency)
+
+        // Start observing BEFORE any Branch initialization to capture all logs
+        // This uses AsyncStream which buffers logs until observer attaches
+        startNetworkLogObserver()
 
         // Retrieve or create the bls_session_id
         let blsSessionId: String
@@ -74,6 +72,53 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // SwiftUI views can use: @ObservedObject var branchState = BranchSessionCoordinator.shared.observableState
 
         return true
+    }
+
+    // MARK: - Modern Network Log Observer (AsyncStream)
+
+    /// Start observing network logs using modern Swift Concurrency.
+    ///
+    /// This approach:
+    /// - Uses `AsyncStream` which automatically buffers logs
+    /// - Eliminates race conditions (logs captured even before observer starts)
+    /// - Uses `for await` for reactive processing
+    /// - Is fully thread-safe via Actor isolation
+    private func startNetworkLogObserver() {
+        logObserverTask = Task { [weak self] in
+            guard let self else { return }
+
+            print("[BranchLinkSimulator] Starting AsyncStream network log observer...")
+
+            // Process logs as they arrive (buffered logs flush immediately)
+            for await entry in BranchNetworkLogger.shared.logStream {
+                // Convert NetworkLogEntry to the format expected by RoundTripStore
+                await MainActor.run {
+                    self.processNetworkLogEntry(entry)
+                }
+            }
+
+            print("[BranchLinkSimulator] Network log observer ended")
+        }
+    }
+
+    /// Process a NetworkLogEntry from the modern logger
+    @MainActor
+    private func processNetworkLogEntry(_ entry: NetworkLogEntry) {
+        // Convert Sendable dictionary back to [String: Any] for compatibility
+        let requestBody = entry.requestBody as [String: Any]
+        let responseBody = entry.responseBody as? [String: Any]
+
+        store.processSwiftNetworkLog(
+            url: entry.url,
+            requestBody: requestBody,
+            responseBody: responseBody,
+            statusCode: entry.statusCode,
+            error: entry.error.map { NSError(domain: "BranchNetwork", code: -1, userInfo: [NSLocalizedDescriptionKey: $0]) }
+        )
+    }
+
+    deinit {
+        logObserverTask?.cancel()
     }
 
     // MARK: - Modern SessionManager Integration

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -6,7 +6,6 @@
 //
 
 import BranchSDK
-import BranchSwiftSDK
 import SwiftUI
 
 struct AlertItem: Identifiable {
@@ -23,11 +22,6 @@ class DeepLinkViewModel: ObservableObject {
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var deepLinkViewModel = DeepLinkViewModel()
     var store = RoundTripStore()
-
-    /// Reference to the modern SessionManager
-    private var sessionManager: SessionManager {
-        SessionManager.shared
-    }
 
     /// Convenience logger
     private var logger: BranchLogger {
@@ -74,37 +68,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set the bls_session_id in Branch request metadata
         Branch.getInstance().setRequestMetadataKey("bls_session_id", value: blsSessionId)
 
-        // MARK: - Initialize with Modern SessionManager
+        // MARK: - Initialize with Branch SDK (Objective-C)
 
-        // Use the new Swift SessionManager for initialization
-        // This provides task coalescing, async/await support, and syncs to BNCPreferenceHelper
-        // so that Legacy SDK features (events, links, QR codes) continue to work
+        logger.logVerbose("Initializing Branch SDK...", error: nil)
 
-        let options = InitializationOptions()
-            .with(launchOptions: launchOptions)
-
-        logger.logVerbose("Initializing with Modern SessionManager...", error: nil)
-
-        sessionManager.initialize(options: options) { [weak self] session, error in
+        Branch.getInstance().initSession(launchOptions: launchOptions) { [weak self] params, error in
             guard let self = self else { return }
 
             if let error = error {
-                self.logger.logError("SessionManager init error: \(error.localizedDescription)", error: error)
+                self.logger.logError("Branch init error: \(error.localizedDescription)", error: error)
                 var message = "Failed to initialize Branch SDK: \(error.localizedDescription)."
                 if config.staging {
                     message += " Are you connected to VPN?"
                 }
                 self.deepLinkViewModel.errorItem = AlertItem(message: message)
-            } else if let session = session {
-                self.logger.logVerbose("SessionManager initialized successfully!", error: nil)
-                self.logger.logDebug("Session ID: \(session.id)", error: nil)
-                self.logger.logDebug("Identity ID: \(session.identityId)", error: nil)
-                self.logger.logDebug("Device Fingerprint: \(session.deviceFingerprintId)", error: nil)
-                self.logger.logDebug("Is First Session: \(session.isFirstSession)", error: nil)
-                self.logger.logDebug("Params: \(session.params)", error: nil)
+            } else if let params = params {
+                self.logger.logVerbose("Branch SDK initialized successfully!", error: nil)
+                self.logger.logDebug("Params: \(params)", error: nil)
 
                 // Handle deep link data if present
-                self.handleSessionInitialized(session)
+                self.handleSessionParams(params)
             }
         }
 
@@ -114,24 +97,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Session Handling
 
     /// Handle successful session initialization
-    private func handleSessionInitialized(_ session: Session) {
+    private func handleSessionParams(_ params: [AnyHashable: Any]) {
         // Check if there's deep link data
-        let clickedBranchLink = session.params["+clicked_branch_link"] as? Bool ?? false
+        let clickedBranchLink = params["+clicked_branch_link"] as? Bool ?? false
 
-        if clickedBranchLink || session.hasDeepLinkData {
+        if clickedBranchLink {
             logger.logVerbose("Deep link detected!", error: nil)
-            logger.logDebug("Deep link params: \(session.params)", error: nil)
+            logger.logDebug("Deep link params: \(params)", error: nil)
 
             // Convert params to the format expected by the UI
             var displayParams: [String: AnyObject] = [:]
-            displayParams["+clicked_branch_link"] = true as AnyObject
-            displayParams["session_id"] = session.id as AnyObject
-            displayParams["identity_id"] = session.identityId as AnyObject
-            displayParams["+is_first_session"] = session.isFirstSession as AnyObject
-
-            // Copy all params from session
-            for (key, value) in session.params {
-                displayParams[key] = value as AnyObject
+            for (key, value) in params {
+                if let stringKey = key as? String {
+                    displayParams[stringKey] = value as AnyObject
+                }
             }
 
             deepLinkViewModel.deepLinkData = displayParams
@@ -156,14 +135,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         logger.logVerbose("Received Universal Link: \(url)", error: nil)
 
-        // Handle via Modern SessionManager
-        sessionManager.handleDeepLink(url) { [weak self] session, error in
-            if let session = session {
-                self?.handleSessionInitialized(session)
-            } else if let error = error {
-                self?.logger.logError("Universal Link error: \(error.localizedDescription)", error: error)
-            }
-        }
+        // Handle via Branch SDK
+        Branch.getInstance().handleDeepLink(url)
 
         return true
     }
@@ -177,14 +150,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
         logger.logVerbose("Received URL Scheme: \(url)", error: nil)
 
-        // Handle via Modern SessionManager
-        sessionManager.handleDeepLink(url) { [weak self] session, error in
-            if let session = session {
-                self?.handleSessionInitialized(session)
-            } else if let error = error {
-                self?.logger.logError("URL Scheme error: \(error.localizedDescription)", error: error)
-            }
-        }
+        // Handle via Branch SDK
+        Branch.getInstance().handleDeepLink(url)
 
         return true
     }

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -43,6 +43,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             self.store.processLog(request, response)
         }
 
+        // Set up logging callback for the new Swift SessionManager network layer
+        DefaultBranchNetworkService.logCallback = { [weak self] url, requestBody, responseBody, statusCode, error in
+            guard let self = self else { return }
+            self.store.processSwiftNetworkLog(
+                url: url,
+                requestBody: requestBody,
+                responseBody: responseBody,
+                statusCode: statusCode,
+                error: error
+            )
+        }
+
         // Retrieve or create the bls_session_id
         let blsSessionId: String
         if let savedId = UserDefaults.standard.string(forKey: "blsSessionId") {

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var deepLinkViewModel = DeepLinkViewModel()
     var store = RoundTripStore()
 
-    /// Convenience logger
+    /// Convenience logger (Objective-C singleton)
     private var logger: BranchLogger {
         BranchLogger.shared()
     }
@@ -35,8 +35,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Branch.setAPIUrl(config.apiUrl)
         Branch.setBranchKey(config.branchKey)
 
-        // Enable verbose logging with callback for console output and RoundTripStore
-        Branch.enableLogging(at: .verbose) { message, logLevel, error, request, response in
+        // Enable verbose logging with advanced callback for console output and RoundTripStore
+        Branch.enableLogging(at: .verbose, withAdvancedCallback: { [weak self] message, logLevel, error, request, response in
             // Log to console (os_log doesn't show verbose/debug in Xcode console)
             let levelStr: String
             switch logLevel {
@@ -46,15 +46,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             case .error: levelStr = "ERROR"
             @unknown default: levelStr = "UNKNOWN"
             }
-            var fullMessage = "[BranchSDK][\(levelStr)] \(message ?? "")"
+            var fullMessage = "[BranchSDK][\(levelStr)] \(message)"
             if let error = error {
                 fullMessage += " Error: \(error.localizedDescription)"
             }
             NSLog("%@", fullMessage)
 
             // Process for RoundTripStore
-            self.store.processLog(request, response)
-        }
+            self?.store.processLog(request, response)
+        })
 
         // Retrieve or create the bls_session_id
         let blsSessionId: String
@@ -68,11 +68,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set the bls_session_id in Branch request metadata
         Branch.getInstance().setRequestMetadataKey("bls_session_id", value: blsSessionId)
 
-        // MARK: - Initialize with Branch SDK (Objective-C)
+        // MARK: - Initialize with Branch SDK (Objective-C API)
 
         logger.logVerbose("Initializing Branch SDK...", error: nil)
 
-        Branch.getInstance().initSession(launchOptions: launchOptions) { [weak self] params, error in
+        Branch.getInstance().initSession(launchOptions: launchOptions, andRegisterDeepLinkHandler: { [weak self] params, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -81,7 +81,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 if config.staging {
                     message += " Are you connected to VPN?"
                 }
-                self.deepLinkViewModel.errorItem = AlertItem(message: message)
+                DispatchQueue.main.async {
+                    self.deepLinkViewModel.errorItem = AlertItem(message: message)
+                }
             } else if let params = params {
                 self.logger.logVerbose("Branch SDK initialized successfully!", error: nil)
                 self.logger.logDebug("Params: \(params)", error: nil)
@@ -89,7 +91,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 // Handle deep link data if present
                 self.handleSessionParams(params)
             }
-        }
+        })
 
         return true
     }
@@ -113,8 +115,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
 
-            deepLinkViewModel.deepLinkData = displayParams
-            deepLinkViewModel.deepLinkHandled = true
+            DispatchQueue.main.async {
+                self.deepLinkViewModel.deepLinkData = displayParams
+                self.deepLinkViewModel.deepLinkHandled = true
+            }
         } else {
             logger.logVerbose("No deep link data - organic session", error: nil)
         }

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -18,7 +18,8 @@ class DeepLinkViewModel: ObservableObject {
     @Published var deepLinkHandled = false
     @Published var deepLinkData: [String: AnyObject]? = nil
     @Published var errorItem: AlertItem? = nil
-    @Published var sessionState: String = "Uninitialized"
+    // Note: Session state is now managed by SDK's BranchObservableState
+    // Access via: BranchSessionCoordinator.shared.observableState.stateDescription
 }
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -57,8 +58,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use the NEW SessionManager for initialization
         initializeWithModernSessionManager(launchOptions: launchOptions, config: config)
 
-        // Start observing session state changes
-        observeSessionState()
+        // Note: Session state observation is handled automatically by SDK's BranchObservableState
+        // SwiftUI views can use: @ObservedObject var branchState = BranchSessionCoordinator.shared.observableState
 
         return true
     }
@@ -142,19 +143,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             deepLinkViewModel.deepLinkHandled = true
         } else {
             print("[BranchLinkSimulator] No deep link data - organic session")
-        }
-    }
-
-    /// Observe session state changes using the new async stream API
-    private func observeSessionState() {
-        Task {
-            for await state in sessionCoordinator.sessionManager.observeState() {
-                await MainActor.run {
-                    // Use SessionState's built-in description
-                    self.deepLinkViewModel.sessionState = state.description
-                    print("[BranchLinkSimulator] State: \(state.description)")
-                }
-            }
         }
     }
 

--- a/BranchLinkSimulator/AppDelegate.swift
+++ b/BranchLinkSimulator/AppDelegate.swift
@@ -18,40 +18,49 @@ class DeepLinkViewModel: ObservableObject {
     @Published var deepLinkHandled = false
     @Published var deepLinkData: [String: AnyObject]? = nil
     @Published var errorItem: AlertItem? = nil
-    // Note: Session state is now managed by SDK's BranchObservableState
-    // Access via: BranchSessionCoordinator.shared.observableState.stateDescription
 }
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var deepLinkViewModel = DeepLinkViewModel()
     var store = RoundTripStore()
 
-    /// Task for observing network logs (keeps the stream alive)
-    private var logObserverTask: Task<Void, Never>?
+    /// Reference to the modern SessionManager
+    private var sessionManager: SessionManager {
+        SessionManager.shared
+    }
 
-    /// Reference to the modern SessionManager via BranchSessionCoordinator
-    private var sessionCoordinator: BranchSessionCoordinator {
-        BranchSessionCoordinator.shared
+    /// Convenience logger
+    private var logger: BranchLogger {
+        BranchLogger.shared()
     }
 
     func application(_: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         let config = loadConfigOrDefault()
 
-        // Configure the legacy SDK for API URL and Branch Key
-        // (still needed for network layer configuration)
+        // Configure the SDK for API URL and Branch Key
         Branch.setAPIUrl(config.apiUrl)
         Branch.setBranchKey(config.branchKey)
 
-        // Legacy SDK logging (for events, links, QR codes)
-        Branch.enableLogging(at: .verbose) { _, _, _, request, response in
+        // Enable verbose logging with callback for console output and RoundTripStore
+        Branch.enableLogging(at: .verbose) { message, logLevel, error, request, response in
+            // Log to console (os_log doesn't show verbose/debug in Xcode console)
+            let levelStr: String
+            switch logLevel {
+            case .verbose: levelStr = "VERBOSE"
+            case .debug: levelStr = "DEBUG"
+            case .warning: levelStr = "WARNING"
+            case .error: levelStr = "ERROR"
+            @unknown default: levelStr = "UNKNOWN"
+            }
+            var fullMessage = "[BranchSDK][\(levelStr)] \(message ?? "")"
+            if let error = error {
+                fullMessage += " Error: \(error.localizedDescription)"
+            }
+            NSLog("%@", fullMessage)
+
+            // Process for RoundTripStore
             self.store.processLog(request, response)
         }
-
-        // MARK: - Modern AsyncStream Logging (Swift Concurrency)
-
-        // Start observing BEFORE any Branch initialization to capture all logs
-        // This uses AsyncStream which buffers logs until observer attaches
-        startNetworkLogObserver()
 
         // Retrieve or create the bls_session_id
         let blsSessionId: String
@@ -65,144 +74,74 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set the bls_session_id in Branch request metadata
         Branch.getInstance().setRequestMetadataKey("bls_session_id", value: blsSessionId)
 
-        // Use the NEW SessionManager for initialization
-        initializeWithModernSessionManager(launchOptions: launchOptions, config: config)
+        // MARK: - Initialize with Modern SessionManager
 
-        // Note: Session state observation is handled automatically by SDK's BranchObservableState
-        // SwiftUI views can use: @ObservedObject var branchState = BranchSessionCoordinator.shared.observableState
+        // Use the new Swift SessionManager for initialization
+        // This provides task coalescing, async/await support, and syncs to BNCPreferenceHelper
+        // so that Legacy SDK features (events, links, QR codes) continue to work
+
+        let options = InitializationOptions()
+            .with(launchOptions: launchOptions)
+
+        logger.logVerbose("Initializing with Modern SessionManager...", error: nil)
+
+        sessionManager.initialize(options: options) { [weak self] session, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                self.logger.logError("SessionManager init error: \(error.localizedDescription)", error: error)
+                var message = "Failed to initialize Branch SDK: \(error.localizedDescription)."
+                if config.staging {
+                    message += " Are you connected to VPN?"
+                }
+                self.deepLinkViewModel.errorItem = AlertItem(message: message)
+            } else if let session = session {
+                self.logger.logVerbose("SessionManager initialized successfully!", error: nil)
+                self.logger.logDebug("Session ID: \(session.id)", error: nil)
+                self.logger.logDebug("Identity ID: \(session.identityId)", error: nil)
+                self.logger.logDebug("Device Fingerprint: \(session.deviceFingerprintId)", error: nil)
+                self.logger.logDebug("Is First Session: \(session.isFirstSession)", error: nil)
+                self.logger.logDebug("Params: \(session.params)", error: nil)
+
+                // Handle deep link data if present
+                self.handleSessionInitialized(session)
+            }
+        }
 
         return true
     }
 
-    // MARK: - Modern Network Log Observer (AsyncStream)
-
-    /// Start observing network logs using modern Swift Concurrency.
-    ///
-    /// This approach:
-    /// - Uses `AsyncStream` which automatically buffers logs
-    /// - Eliminates race conditions (logs captured even before observer starts)
-    /// - Uses `for await` for reactive processing
-    /// - Is fully thread-safe via Actor isolation
-    private func startNetworkLogObserver() {
-        logObserverTask = Task { [weak self] in
-            guard let self else { return }
-
-            print("[BranchLinkSimulator] Starting AsyncStream network log observer...")
-
-            // Process logs as they arrive (buffered logs flush immediately)
-            for await entry in BranchNetworkLogger.shared.logStream {
-                // Convert NetworkLogEntry to the format expected by RoundTripStore
-                await MainActor.run {
-                    self.processNetworkLogEntry(entry)
-                }
-            }
-
-            print("[BranchLinkSimulator] Network log observer ended")
-        }
-    }
-
-    /// Process a NetworkLogEntry from the modern logger
-    @MainActor
-    private func processNetworkLogEntry(_ entry: NetworkLogEntry) {
-        // Convert Sendable dictionary back to [String: Any] for compatibility
-        let requestBody = entry.requestBody as [String: Any]
-        let responseBody = entry.responseBody as? [String: Any]
-
-        store.processSwiftNetworkLog(
-            url: entry.url,
-            requestBody: requestBody,
-            responseBody: responseBody,
-            statusCode: entry.statusCode,
-            error: entry.error.map { NSError(domain: "BranchNetwork", code: -1, userInfo: [NSLocalizedDescriptionKey: $0]) }
-        )
-    }
-
-    deinit {
-        logObserverTask?.cancel()
-    }
-
-    // MARK: - Modern SessionManager Integration
-
-    /// Initialize Branch using the new Swift SessionManager with task coalescing
-    @MainActor
-    private func initializeWithModernSessionManager(
-        launchOptions: [UIApplication.LaunchOptionsKey: Any]?,
-        config: ApiConfiguration
-    ) {
-        Task {
-            do {
-                // Build initialization options using the builder pattern
-                let options = InitializationOptions()
-                    .with(launchOptions: launchOptions)
-
-                print("[BranchLinkSimulator] Initializing with modern SessionManager...")
-
-                // Initialize using the new SessionManager
-                let session = try await sessionCoordinator.sessionManager.initialize(options: options)
-
-                print("[BranchLinkSimulator] Session initialized: \(session)")
-
-                // Convert session to params format for UI compatibility
-                await MainActor.run {
-                    handleSessionInitialized(session, config: config)
-                }
-
-            } catch {
-                print("[BranchLinkSimulator] Session initialization failed: \(error)")
-
-                await MainActor.run {
-                    var message = "Failed to initialize Branch SDK: \(error.localizedDescription)."
-                    if config.staging {
-                        message += " Are you connected to VPN?"
-                    }
-                    self.deepLinkViewModel.errorItem = AlertItem(message: message)
-                }
-            }
-        }
-    }
-
-    /// Handle session for UI updates (called from BranchLinkSimulatorApp onOpenURL)
-    @MainActor
-    func handleSessionForUI(_ session: Session) {
-        let config = loadConfigOrDefault()
-        handleSessionInitialized(session, config: config)
-    }
+    // MARK: - Session Handling
 
     /// Handle successful session initialization
-    @MainActor
-    private func handleSessionInitialized(_ session: Session, config _: ApiConfiguration) {
-        print("[BranchLinkSimulator] Session ID: \(session.id)")
-        print("[BranchLinkSimulator] Identity ID: \(session.identityId)")
-        print("[BranchLinkSimulator] Is First Session: \(session.isFirstSession)")
-
+    private func handleSessionInitialized(_ session: Session) {
         // Check if there's deep link data
-        if let linkData = session.linkData {
-            print("[BranchLinkSimulator] Deep link detected: \(linkData)")
+        let clickedBranchLink = session.params["+clicked_branch_link"] as? Bool ?? false
 
-            // Convert to the format expected by the existing UI
-            var params: [String: AnyObject] = [:]
-            params["+clicked_branch_link"] = true as AnyObject
-            params["session_id"] = session.id as AnyObject
-            params["identity_id"] = session.identityId as AnyObject
-            params["+is_first_session"] = session.isFirstSession as AnyObject
+        if clickedBranchLink || session.hasDeepLinkData {
+            logger.logVerbose("Deep link detected!", error: nil)
+            logger.logDebug("Deep link params: \(session.params)", error: nil)
 
-            if let url = linkData.url {
-                params["~referring_link"] = url.absoluteString as AnyObject
+            // Convert params to the format expected by the UI
+            var displayParams: [String: AnyObject] = [:]
+            displayParams["+clicked_branch_link"] = true as AnyObject
+            displayParams["session_id"] = session.id as AnyObject
+            displayParams["identity_id"] = session.identityId as AnyObject
+            displayParams["+is_first_session"] = session.isFirstSession as AnyObject
+
+            // Copy all params from session
+            for (key, value) in session.params {
+                displayParams[key] = value as AnyObject
             }
 
-            // Add custom parameters from link data
-            for (key, value) in linkData.parameters {
-                params[key] = value.value as AnyObject
-            }
-
-            deepLinkViewModel.deepLinkData = params
+            deepLinkViewModel.deepLinkData = displayParams
             deepLinkViewModel.deepLinkHandled = true
         } else {
-            print("[BranchLinkSimulator] No deep link data - organic session")
+            logger.logVerbose("No deep link data - organic session", error: nil)
         }
     }
 
-    // MARK: - Universal Links (Scene-based apps)
+    // MARK: - Universal Links
 
     func application(
         _: UIApplication,
@@ -215,22 +154,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return false
         }
 
-        print("[BranchLinkSimulator] Received Universal Link: \(url)")
+        logger.logVerbose("Received Universal Link: \(url)", error: nil)
 
-        // Handle via the new SessionManager (task coalescing will merge if initialization is in progress)
-        Task {
-            do {
-                var options = InitializationOptions()
-                options.url = url
-
-                let session = try await sessionCoordinator.sessionManager.initialize(options: options)
-
-                await MainActor.run {
-                    let config = loadConfigOrDefault()
-                    handleSessionInitialized(session, config: config)
-                }
-            } catch {
-                print("[BranchLinkSimulator] Universal Link handling failed: \(error)")
+        // Handle via Modern SessionManager
+        sessionManager.handleDeepLink(url) { [weak self] session, error in
+            if let session = session {
+                self?.handleSessionInitialized(session)
+            } else if let error = error {
+                self?.logger.logError("Universal Link error: \(error.localizedDescription)", error: error)
             }
         }
 
@@ -242,24 +173,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(
         _: UIApplication,
         open url: URL,
-        options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+        options _: [UIApplication.OpenURLOptionsKey: Any] = [:]
     ) -> Bool {
-        print("[BranchLinkSimulator] Received URL Scheme: \(url)")
+        logger.logVerbose("Received URL Scheme: \(url)", error: nil)
 
-        Task {
-            do {
-                var initOptions = InitializationOptions()
-                initOptions.url = url
-                initOptions.sourceApplication = options[.sourceApplication] as? String
-
-                let session = try await sessionCoordinator.sessionManager.initialize(options: initOptions)
-
-                await MainActor.run {
-                    let config = loadConfigOrDefault()
-                    handleSessionInitialized(session, config: config)
-                }
-            } catch {
-                print("[BranchLinkSimulator] URL Scheme handling failed: \(error)")
+        // Handle via Modern SessionManager
+        sessionManager.handleDeepLink(url) { [weak self] session, error in
+            if let session = session {
+                self?.handleSessionInitialized(session)
+            } else if let error = error {
+                self?.logger.logError("URL Scheme error: \(error.localizedDescription)", error: error)
             }
         }
 

--- a/BranchLinkSimulator/BranchLinkSimulatorApp.swift
+++ b/BranchLinkSimulator/BranchLinkSimulatorApp.swift
@@ -19,22 +19,23 @@ struct BranchLinkSimulatorApp: App {
                 .environmentObject(appDelegate.deepLinkViewModel)
                 .environmentObject(appDelegate.store)
                 .onOpenURL { url in
-                    // Use the modern SessionManager for consistent deep link handling
-                    // This ensures task coalescing works correctly across all entry points
-                    Task {
-                        do {
-                            var options = InitializationOptions()
-                            options.url = url
+                    // Use the Modern SessionManager for URL handling
+                    BranchLogger.shared().logVerbose("onOpenURL: \(url)", error: nil)
 
-                            let session = try await BranchSessionCoordinator.shared.sessionManager.initialize(options: options)
-                            print("[BranchLinkSimulator] onOpenURL handled: \(session.id)")
-
-                            // Update ViewModel on main actor
-                            await MainActor.run {
-                                appDelegate.handleSessionForUI(session)
+                    SessionManager.shared.handleDeepLink(url) { session, error in
+                        if let session = session {
+                            BranchLogger.shared().logDebug("onOpenURL session: \(session.id)", error: nil)
+                            // Update ViewModel for deep link handling
+                            if session.hasDeepLinkData || (session.params["+clicked_branch_link"] as? Bool ?? false) {
+                                var displayParams: [String: AnyObject] = [:]
+                                for (key, value) in session.params {
+                                    displayParams[key] = value as AnyObject
+                                }
+                                appDelegate.deepLinkViewModel.deepLinkData = displayParams
+                                appDelegate.deepLinkViewModel.deepLinkHandled = true
                             }
-                        } catch {
-                            print("[BranchLinkSimulator] onOpenURL failed: \(error)")
+                        } else if let error = error {
+                            BranchLogger.shared().logError("onOpenURL error: \(error.localizedDescription)", error: error)
                         }
                     }
                 }

--- a/BranchLinkSimulator/BranchLinkSimulatorApp.swift
+++ b/BranchLinkSimulator/BranchLinkSimulatorApp.swift
@@ -6,7 +6,6 @@
 //
 
 import BranchSDK
-import BranchSwiftSDK
 import SwiftUI
 
 @main
@@ -19,25 +18,11 @@ struct BranchLinkSimulatorApp: App {
                 .environmentObject(appDelegate.deepLinkViewModel)
                 .environmentObject(appDelegate.store)
                 .onOpenURL { url in
-                    // Use the Modern SessionManager for URL handling
+                    // Use Branch SDK for URL handling
                     BranchLogger.shared().logVerbose("onOpenURL: \(url)", error: nil)
 
-                    SessionManager.shared.handleDeepLink(url) { session, error in
-                        if let session = session {
-                            BranchLogger.shared().logDebug("onOpenURL session: \(session.id)", error: nil)
-                            // Update ViewModel for deep link handling
-                            if session.hasDeepLinkData || (session.params["+clicked_branch_link"] as? Bool ?? false) {
-                                var displayParams: [String: AnyObject] = [:]
-                                for (key, value) in session.params {
-                                    displayParams[key] = value as AnyObject
-                                }
-                                appDelegate.deepLinkViewModel.deepLinkData = displayParams
-                                appDelegate.deepLinkViewModel.deepLinkHandled = true
-                            }
-                        } else if let error = error {
-                            BranchLogger.shared().logError("onOpenURL error: \(error.localizedDescription)", error: error)
-                        }
-                    }
+                    // Handle the deep link - Branch SDK will call the init callback
+                    Branch.getInstance().handleDeepLink(url)
                 }
         }
     }

--- a/BranchLinkSimulator/BranchLinkSimulatorApp.swift
+++ b/BranchLinkSimulator/BranchLinkSimulatorApp.swift
@@ -5,8 +5,9 @@
 //  Created by Nipun Singh on 2/8/24.
 //
 
-import SwiftUI
 import BranchSDK
+import BranchSwiftSDK
+import SwiftUI
 
 @main
 struct BranchLinkSimulatorApp: App {
@@ -17,9 +18,26 @@ struct BranchLinkSimulatorApp: App {
             HomeView()
                 .environmentObject(appDelegate.deepLinkViewModel)
                 .environmentObject(appDelegate.store)
-                .onOpenURL(perform: { url in
-                    Branch.getInstance().handleDeepLink(url)
-                })
+                .onOpenURL { url in
+                    // Use the modern SessionManager for consistent deep link handling
+                    // This ensures task coalescing works correctly across all entry points
+                    Task {
+                        do {
+                            var options = InitializationOptions()
+                            options.url = url
+
+                            let session = try await BranchSessionCoordinator.shared.sessionManager.initialize(options: options)
+                            print("[BranchLinkSimulator] onOpenURL handled: \(session.id)")
+
+                            // Update ViewModel on main actor
+                            await MainActor.run {
+                                appDelegate.handleSessionForUI(session)
+                            }
+                        } catch {
+                            print("[BranchLinkSimulator] onOpenURL failed: \(error)")
+                        }
+                    }
+                }
         }
     }
 }

--- a/BranchLinkSimulator/HomeView.swift
+++ b/BranchLinkSimulator/HomeView.swift
@@ -23,127 +23,121 @@ struct HomeView: View {
     @State private var showingEventActionSheet = false
     @State private var selectedEventType: BranchStandardEvent = .purchase
 
-    @State private var showingQRSheet = false
     @State private var qrCodeImage: UIImage? = nil
 
     var body: some View {
-        NavigationView {
-            VStack {
-                if deepLinkViewModel.deepLinkHandled, let deepLinkData = deepLinkViewModel.deepLinkData {
-                    NavigationLink(destination: DeeplinkDetailView(pageTitle: deepLinkData["page"] as? String ?? "Data", deepLinkParameters: deepLinkData), isActive: $deepLinkViewModel.deepLinkHandled) {
-                        EmptyView()
+        NavigationStack {
+            List {
+                Section(header: Text("Deep Link Pages")) {
+                    NavigationLink(destination: DeeplinkDetailView(pageTitle: "Tree", deepLinkParameters: [:])) {
+                        Label("Go to Tree", systemImage: "tree.fill")
                     }
-                } else {
-                    List {
-                        Section(header: Text("Deep Link Pages")) {
-                            NavigationLink(destination: DeeplinkDetailView(pageTitle: "Tree", deepLinkParameters: [:])) {
-                                Label("Go to Tree", systemImage: "tree.fill")
-                            }
-                            NavigationLink(destination: DeeplinkDetailView(pageTitle: "Twig", deepLinkParameters: [:])) {
-                                Label("Go to Twig", systemImage: "line.diagonal")
-                            }
-                            NavigationLink(destination: DeeplinkDetailView(pageTitle: "Leaf", deepLinkParameters: [:])) {
-                                Label("Go to Leaf", systemImage: "leaf.fill")
-                            }
-                        }
-                        .headerProminence(.standard)
-
-                        Section(header: Text("Events")) {
-                            Button(action: { self.showingEventActionSheet = true }) {
-                                Label("Send Standard Event", systemImage: "paperplane.fill")
-                                    .labelStyle(.titleAndIcon)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color.blue)
-                                    .cornerRadius(8)
-                            }
-                            .actionSheet(isPresented: $showingEventActionSheet) {
-                                ActionSheet(title: Text("Choose Event Type"), message: nil, buttons: [
-                                    .default(Text("Purchase"), action: { sendEventOfType(.purchase) }),
-                                    .default(Text("Add to Cart"), action: { sendEventOfType(.addToCart) }),
-                                    .default(Text("Login"), action: { sendEventOfType(.login) }),
-                                    .default(Text("Search"), action: { sendEventOfType(.search) }),
-                                    .default(Text("Share"), action: { sendEventOfType(.share) }),
-
-                                    .cancel(),
-                                ])
-                            }
-                            Button(action: sendCustomEvent) {
-                                Label("Send Custom Event", systemImage: "paperplane")
-                                    .labelStyle(.titleAndIcon)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color.blue)
-                                    .cornerRadius(8)
-                            }
-                            Button(action: createURL) {
-                                Label("Create Branch Link", systemImage: "link")
-                                    .labelStyle(.titleAndIcon)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color.blue)
-                                    .cornerRadius(8)
-                            }
-                            Button(action: createQRCode) {
-                                Label("Create Branch QR Code", systemImage: "qrcode")
-                                    .labelStyle(.titleAndIcon)
-                                    .foregroundColor(.white)
-                                    .padding()
-                                    .frame(maxWidth: .infinity)
-                                    .background(Color.blue)
-                                    .cornerRadius(8)
-                            }
-                            .sheet(isPresented: .constant(showingQRSheet), onDismiss: {
-                                showingQRSheet = false
-                            }) {
-                                if let qrImage = qrCodeImage {
-                                    Image(uiImage: qrImage)
-                                        .interpolation(.none)
-                                        .resizable()
-                                        .scaledToFit()
-                                } else {
-                                    Text("No QR Code Available")
-                                }
-                            }
-                        }
-                        .headerProminence(.standard)
-                        .listRowSeparator(.hidden)
-
-                        Section("API Settings") {
-                            ApiSettingsView(store: store)
-                        }
-
-                        Section(header: Text("Event Settings"), footer: Text("Branch SDK v3.7.0").frame(maxWidth: .infinity)) {
-                            VStack(alignment: .leading) {
-                                Text("Customer Event Alias")
-                                    .font(.headline)
-                                TextField("Eg. customAlias", text: $eventAlias)
-                                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                            }
-                            .padding(.vertical, 8)
-
-                            VStack(alignment: .leading) {
-                                Text("Branch Link Simulator Session ID")
-                                    .font(.headline)
-                                TextField("ID Goes Here", text: $sessionID)
-                                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                            }
-                            .padding(.vertical, 8)
-
-                            Button("Save Settings") {
-                                saveSettings()
-                            }
-                            .foregroundColor(.blue)
-                        }
-                        .headerProminence(.standard)
+                    NavigationLink(destination: DeeplinkDetailView(pageTitle: "Twig", deepLinkParameters: [:])) {
+                        Label("Go to Twig", systemImage: "line.diagonal")
+                    }
+                    NavigationLink(destination: DeeplinkDetailView(pageTitle: "Leaf", deepLinkParameters: [:])) {
+                        Label("Go to Leaf", systemImage: "leaf.fill")
                     }
                 }
+                .headerProminence(.standard)
+
+                Section(header: Text("Events")) {
+                    Button(action: { self.showingEventActionSheet = true }) {
+                        Label("Send Standard Event", systemImage: "paperplane.fill")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                    .actionSheet(isPresented: $showingEventActionSheet) {
+                        ActionSheet(title: Text("Choose Event Type"), message: nil, buttons: [
+                            .default(Text("Purchase"), action: { sendEventOfType(.purchase) }),
+                            .default(Text("Add to Cart"), action: { sendEventOfType(.addToCart) }),
+                            .default(Text("Login"), action: { sendEventOfType(.login) }),
+                            .default(Text("Search"), action: { sendEventOfType(.search) }),
+                            .default(Text("Share"), action: { sendEventOfType(.share) }),
+                            .cancel(),
+                        ])
+                    }
+                    Button(action: sendCustomEvent) {
+                        Label("Send Custom Event", systemImage: "paperplane")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                    Button(action: createURL) {
+                        Label("Create Branch Link", systemImage: "link")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                    Button(action: createQRCode) {
+                        Label("Create Branch QR Code", systemImage: "qrcode")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundColor(.white)
+                            .padding()
+                            .frame(maxWidth: .infinity)
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                    }
+                    .sheet(isPresented: Binding(
+                        get: { qrCodeImage != nil },
+                        set: { if !$0 { qrCodeImage = nil } }
+                    )) {
+                        if let qrImage = qrCodeImage {
+                            Image(uiImage: qrImage)
+                                .interpolation(.none)
+                                .resizable()
+                                .scaledToFit()
+                        }
+                    }
+                }
+                .headerProminence(.standard)
+                .listRowSeparator(.hidden)
+
+                Section("API Settings") {
+                    ApiSettingsView(store: store)
+                }
+
+                Section(header: Text("Event Settings"), footer: Text("Branch SDK (Objective-C)").frame(maxWidth: .infinity)) {
+                    VStack(alignment: .leading) {
+                        Text("Customer Event Alias")
+                            .font(.headline)
+                        TextField("Eg. customAlias", text: $eventAlias)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                    }
+                    .padding(.vertical, 8)
+
+                    VStack(alignment: .leading) {
+                        Text("Branch Link Simulator Session ID")
+                            .font(.headline)
+                        TextField("ID Goes Here", text: $sessionID)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                    }
+                    .padding(.vertical, 8)
+
+                    Button("Save Settings") {
+                        saveSettings()
+                    }
+                    .foregroundColor(.blue)
+                }
+                .headerProminence(.standard)
             }
             .navigationTitle("Branch Link Simulator")
             .navigationBarTitleDisplayMode(.large)
+            .navigationDestination(isPresented: $deepLinkViewModel.deepLinkHandled) {
+                if let deepLinkData = deepLinkViewModel.deepLinkData {
+                    DeeplinkDetailView(pageTitle: deepLinkData["page"] as? String ?? "Data", deepLinkParameters: deepLinkData)
+                }
+            }
             .onAppear {
                 requestIDFAPermission()
             }
@@ -166,12 +160,12 @@ struct HomeView: View {
         let event = BranchEvent.standardEvent(eventType)
         event.alias = eventAlias
         event.customData["bls_session_id"] = sessionID
-        event.logEvent { result, error in
+        event.logEvent { success, error in
             if let error = error {
                 BranchLogger.shared().logError("Event error: \(error.localizedDescription)", error: error)
                 self.showToast(message: "Error Sending \(eventType.rawValue) Event!")
             } else {
-                BranchLogger.shared().logVerbose("Event sent successfully: \(result)", error: nil)
+                BranchLogger.shared().logVerbose("Event sent successfully (success=\(success))", error: nil)
                 self.showToast(message: "Sent \(eventType.rawValue) Event!")
             }
         }
@@ -182,12 +176,12 @@ struct HomeView: View {
         let event = BranchEvent.customEvent(withName: "testedCustomEvent")
         event.alias = eventAlias
         event.customData["bls_session_id"] = sessionID
-        event.logEvent { result, error in
+        event.logEvent { success, error in
             if let error = error {
                 BranchLogger.shared().logError("Custom event error: \(error.localizedDescription)", error: error)
                 self.showToast(message: "Error Sending Custom Event!")
             } else {
-                BranchLogger.shared().logVerbose("Custom event sent successfully: \(result)", error: nil)
+                BranchLogger.shared().logVerbose("Custom event sent successfully (success=\(success))", error: nil)
                 self.showToast(message: "Sent Custom Event!")
             }
         }
@@ -255,7 +249,6 @@ struct HomeView: View {
                     self.showToast(message: "Error creating QR Code: \(error.localizedDescription)")
                 } else if let image = image {
                     self.qrCodeImage = image
-                    self.showingQRSheet = true
                 }
             }
         }

--- a/BranchLinkSimulator/HomeView.swift
+++ b/BranchLinkSimulator/HomeView.swift
@@ -1,14 +1,14 @@
 //
-//  ContentView.swift
+//  HomeView.swift
 //  BranchLinkSimulator
 //
 //  Created by Nipun Singh on 2/8/24.
 //
 
-import SwiftUI
-import BranchSDK
-import AppTrackingTransparency
 import AdSupport
+import AppTrackingTransparency
+import BranchSDK
+import SwiftUI
 
 struct HomeView: View {
     @EnvironmentObject var deepLinkViewModel: DeepLinkViewModel
@@ -22,10 +22,10 @@ struct HomeView: View {
 
     @State private var showingEventActionSheet = false
     @State private var selectedEventType: BranchStandardEvent = .purchase
-    
+
     @State private var showingQRSheet = false
     @State private var qrCodeImage: UIImage? = nil
-    
+
     var body: some View {
         NavigationView {
             VStack {
@@ -47,7 +47,7 @@ struct HomeView: View {
                             }
                         }
                         .headerProminence(.standard)
-                        
+
                         Section(header: Text("Events")) {
                             Button(action: { self.showingEventActionSheet = true }) {
                                 Label("Send Standard Event", systemImage: "paperplane.fill")
@@ -66,7 +66,7 @@ struct HomeView: View {
                                     .default(Text("Search"), action: { sendEventOfType(.search) }),
                                     .default(Text("Share"), action: { sendEventOfType(.share) }),
 
-                                    .cancel()
+                                    .cancel(),
                                 ])
                             }
                             Button(action: sendCustomEvent) {
@@ -111,12 +111,11 @@ struct HomeView: View {
                         }
                         .headerProminence(.standard)
                         .listRowSeparator(.hidden)
-                    
-                        
+
                         Section("API Settings") {
                             ApiSettingsView(store: store)
                         }
-                        
+
                         Section(header: Text("Event Settings"), footer: Text("Branch SDK v3.7.0").frame(maxWidth: .infinity)) {
                             VStack(alignment: .leading) {
                                 Text("Customer Event Alias")
@@ -125,7 +124,7 @@ struct HomeView: View {
                                     .textFieldStyle(RoundedBorderTextFieldStyle())
                             }
                             .padding(.vertical, 8)
-                            
+
                             VStack(alignment: .leading) {
                                 Text("Branch Link Simulator Session ID")
                                     .font(.headline)
@@ -138,7 +137,6 @@ struct HomeView: View {
                                 saveSettings()
                             }
                             .foregroundColor(.blue)
-                            
                         }
                         .headerProminence(.standard)
                     }
@@ -155,91 +153,100 @@ struct HomeView: View {
             deepLinkViewModel.deepLinkHandled = false
         }
         .alert(item: $deepLinkViewModel.errorItem) { errorItem in
-                    Alert(
-                        title: Text("Error"),
-                        message: Text(errorItem.message),
-                        dismissButton: .default(Text("OK"))
-                    )
-                }
+            Alert(
+                title: Text("Error"),
+                message: Text(errorItem.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
     }
-    
+
     func sendEventOfType(_ eventType: BranchStandardEvent) {
+        BranchLogger.shared().logVerbose("Sending standard event: \(eventType.rawValue)", error: nil)
         let event = BranchEvent.standardEvent(eventType)
         event.alias = eventAlias
         event.customData["bls_session_id"] = sessionID
         event.logEvent { result, error in
-            if error == nil {
-                self.showToast(message: "Sent \(eventType.rawValue) Event!")
-            } else {
+            if let error = error {
+                BranchLogger.shared().logError("Event error: \(error.localizedDescription)", error: error)
                 self.showToast(message: "Error Sending \(eventType.rawValue) Event!")
+            } else {
+                BranchLogger.shared().logVerbose("Event sent successfully: \(result)", error: nil)
+                self.showToast(message: "Sent \(eventType.rawValue) Event!")
             }
         }
     }
-    
+
     func sendCustomEvent() {
-        let event = BranchEvent.customEvent(withName:"testedCustomEvent")
+        BranchLogger.shared().logVerbose("Sending custom event: testedCustomEvent", error: nil)
+        let event = BranchEvent.customEvent(withName: "testedCustomEvent")
         event.alias = eventAlias
         event.customData["bls_session_id"] = sessionID
         event.logEvent { result, error in
-            if error == nil {
-                self.showToast(message: "Sent Custom Event!")
-            } else {
+            if let error = error {
+                BranchLogger.shared().logError("Custom event error: \(error.localizedDescription)", error: error)
                 self.showToast(message: "Error Sending Custom Event!")
+            } else {
+                BranchLogger.shared().logVerbose("Custom event sent successfully: \(result)", error: nil)
+                self.showToast(message: "Sent Custom Event!")
             }
         }
     }
-    
+
     func saveSettings() {
-        print("Setting API URL to  \(branchAPIURL)")
+        BranchLogger.shared().logDebug("Setting API URL to \(branchAPIURL)", error: nil)
         Branch.setAPIUrl(branchAPIURL)
-                
+
         UserDefaults.standard.set(eventAlias, forKey: "customerEventAlias")
         UserDefaults.standard.set(sessionID, forKey: "blsSessionId")
-        
+
         Branch.getInstance().setRequestMetadataKey("bls_session_id", value: sessionID)
-        
-        self.showToast(message: "Saved Settings!")
-     }
-    
+
+        showToast(message: "Saved Settings!")
+    }
+
     func showToast(message: String) {
-        self.toastMessage = message
-        self.showingToast = true
+        toastMessage = message
+        showingToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             self.showingToast = false
         }
     }
-    
+
     func requestIDFAPermission() {
         if #available(iOS 14, *) {
             DispatchQueue.main.async {
-                ATTrackingManager.requestTrackingAuthorization { (status) in
-                    if (status == .authorized) {
+                ATTrackingManager.requestTrackingAuthorization { status in
+                    if status == .authorized {
                         let idfa = ASIdentifierManager.shared().advertisingIdentifier
-                        print("IDFA: " + idfa.uuidString)
+                        BranchLogger.shared().logDebug("IDFA: \(idfa.uuidString)", error: nil)
                     } else {
-                        print("Failed to get IDFA")
+                        BranchLogger.shared().logWarning("Failed to get IDFA", error: nil)
                     }
                 }
             }
         }
     }
-    
+
     func createURL() {
-        let buo: BranchUniversalObject = BranchUniversalObject(canonicalIdentifier: "item/12345")
-        let lp: BranchLinkProperties = BranchLinkProperties()
+        BranchLogger.shared().logVerbose("Creating Branch link...", error: nil)
+        let buo = BranchUniversalObject(canonicalIdentifier: "item/12345")
+        let lp = BranchLinkProperties()
 
         buo.getShortUrl(with: lp) { url, error in
             if let error = error {
+                BranchLogger.shared().logError("Link creation error: \(error.localizedDescription)", error: error)
                 self.showToast(message: "Error creating link: \(error)")
             } else {
+                BranchLogger.shared().logVerbose("Link created: \(url ?? "N/A")", error: nil)
                 self.showToast(message: "Created \(url ?? "N/A")")
             }
         }
     }
-    
+
     func createQRCode() {
-        let buo: BranchUniversalObject = BranchUniversalObject(canonicalIdentifier: "item/12345")
-        let lp: BranchLinkProperties = BranchLinkProperties()
+        let buo = BranchUniversalObject(canonicalIdentifier: "item/12345")
+        let lp = BranchLinkProperties()
 
         let qrCode = BranchQRCode()
         qrCode.getAsImage(buo, linkProperties: lp) { image, error in
@@ -253,14 +260,13 @@ struct HomeView: View {
             }
         }
     }
-
 }
 
 extension View {
     func toast(isShowing: Binding<Bool>, message: String) -> some View {
         ZStack(alignment: .bottom) {
             self
-            
+
             if isShowing.wrappedValue {
                 VStack {
                     Spacer()
@@ -285,7 +291,6 @@ extension View {
         .animation(.easeInOut, value: isShowing.wrappedValue)
     }
 }
-
 
 #Preview {
     HomeView()

--- a/BranchLinkSimulator/RoundTripStore.swift
+++ b/BranchLinkSimulator/RoundTripStore.swift
@@ -1,9 +1,9 @@
-import Foundation
 import BranchSDK
+import Foundation
 
 class RoundTripStore: ObservableObject {
     let FAILED = "failed to parse"
-    
+
     @Published var roundTrips: [RoundTrip] = [] {
         didSet {
             saveRoundTrips()
@@ -38,7 +38,6 @@ class RoundTripStore: ObservableObject {
         if roundTrips.count > 30 {
             roundTrips = Array(roundTrips.prefix(30))
         }
-    
     }
 
     private func sortRoundTrips() {
@@ -63,7 +62,7 @@ class RoundTripStore: ObservableObject {
             print("Failed to load round trips: \(error)")
         }
     }
-    
+
     func processLog(_ request: NSMutableURLRequest?, _ response: BNCServerResponse?) {
         if let req = request {
             let branchReq = process(request: req)
@@ -75,18 +74,63 @@ class RoundTripStore: ObservableObject {
         }
     }
 
+    /// Process network logs from the new Swift SessionManager
+    func processSwiftNetworkLog(
+        url: String,
+        requestBody: [String: Any],
+        responseBody: [String: Any]?,
+        statusCode: Int?,
+        error: Error?
+    ) {
+        // Convert request body to pretty JSON string
+        var requestBodyString = FAILED
+        if let jsonData = try? JSONSerialization.data(withJSONObject: requestBody, options: .prettyPrinted),
+           let jsonString = String(data: jsonData, encoding: .utf8)
+        {
+            requestBodyString = jsonString
+        }
+
+        let branchRequest = BranchRequest(
+            headers: "[Swift SessionManager - POST]",
+            body: requestBodyString
+        )
+
+        addRoundTrip(with: branchRequest, url: url)
+
+        // Add response if available
+        if let responseBody = responseBody {
+            var responseBodyString = FAILED
+            if let jsonData = try? JSONSerialization.data(withJSONObject: responseBody, options: .prettyPrinted),
+               let jsonString = String(data: jsonData, encoding: .utf8)
+            {
+                responseBodyString = jsonString
+            }
+
+            let statusCodeString = statusCode.map { String($0) } ?? FAILED
+            let branchResponse = BranchResponse(statusCode: statusCodeString, body: responseBodyString)
+            addResponse(branchResponse)
+        } else if let error = error {
+            // Add error response
+            let branchResponse = BranchResponse(
+                statusCode: statusCode.map { String($0) } ?? "Error",
+                body: "Error: \(error.localizedDescription)"
+            )
+            addResponse(branchResponse)
+        }
+    }
+
     func process(request req: NSMutableURLRequest) -> BranchRequest {
         let body = req.httpBody.flatMap { String(data: $0, encoding: .utf8) }
-        
+
         return BranchRequest(
             headers: req.allHTTPHeaderFields?.description ?? FAILED,
             body: body ?? FAILED
         )
     }
-    
+
     func process(response resp: BNCServerResponse) -> BranchResponse {
         let statusCode = String(resp.statusCode.intValue)
-        
+
         var body = FAILED
         if let dictionary = resp.data as? NSDictionary {
             do {
@@ -99,5 +143,3 @@ class RoundTripStore: ObservableObject {
         return BranchResponse(statusCode: statusCode, body: body)
     }
 }
-
-

--- a/BranchLinkSimulator/RoundTripStore.swift
+++ b/BranchLinkSimulator/RoundTripStore.swift
@@ -74,51 +74,6 @@ class RoundTripStore: ObservableObject {
         }
     }
 
-    /// Process network logs from the new Swift SessionManager
-    func processSwiftNetworkLog(
-        url: String,
-        requestBody: [String: Any],
-        responseBody: [String: Any]?,
-        statusCode: Int?,
-        error: Error?
-    ) {
-        // Convert request body to pretty JSON string
-        var requestBodyString = FAILED
-        if let jsonData = try? JSONSerialization.data(withJSONObject: requestBody, options: .prettyPrinted),
-           let jsonString = String(data: jsonData, encoding: .utf8)
-        {
-            requestBodyString = jsonString
-        }
-
-        let branchRequest = BranchRequest(
-            headers: "[Swift SessionManager - POST]",
-            body: requestBodyString
-        )
-
-        addRoundTrip(with: branchRequest, url: url)
-
-        // Add response if available
-        if let responseBody = responseBody {
-            var responseBodyString = FAILED
-            if let jsonData = try? JSONSerialization.data(withJSONObject: responseBody, options: .prettyPrinted),
-               let jsonString = String(data: jsonData, encoding: .utf8)
-            {
-                responseBodyString = jsonString
-            }
-
-            let statusCodeString = statusCode.map { String($0) } ?? FAILED
-            let branchResponse = BranchResponse(statusCode: statusCodeString, body: responseBodyString)
-            addResponse(branchResponse)
-        } else if let error = error {
-            // Add error response
-            let branchResponse = BranchResponse(
-                statusCode: statusCode.map { String($0) } ?? "Error",
-                body: "Error: \(error.localizedDescription)"
-            )
-            addResponse(branchResponse)
-        }
-    }
-
     func process(request req: NSMutableURLRequest) -> BranchRequest {
         let body = req.httpBody.flatMap { String(data: $0, encoding: .utf8) }
 


### PR DESCRIPTION
## Summary

Integrate the new Swift SessionManager into BranchLinkSimulator to test the modern async/await API with task coalescing for Double Open prevention (INTENG-21106).

### Changes

**SPM Integration**
- Remove prebuilt `BranchSDK.xcframework` reference
- Add local SPM package reference to `../ios-branch-deep-linking-attribution`
- Configure `BranchSDK` package product dependency

**Modern SessionManager Integration**
- Add `BranchSwiftSDK` import for SessionManager access
- Use `BranchSessionCoordinator.shared.sessionManager` for modern API
- Replace callback-based `initSession` with async/await `initialize(options:)`
- Implement state observation via `AsyncStream<SessionState>`
- Update Universal Links and URL Scheme handlers to use SessionManager

### Technical Details

The new SessionManager provides:
- **Task coalescing**: Multiple concurrent `initialize()` calls are merged into a single API request
- **Async/await API**: Modern Swift concurrency patterns
- **Actor-based thread safety**: Full Swift 6 concurrency compliance
- **AsyncStream observation**: Reactive state updates for UI

### Testing

- [ ] App launches successfully
- [ ] Session initializes correctly
- [ ] Deep links are handled
- [ ] Universal links are handled
- [ ] State updates are reflected in UI

---
*Related: EMT-2878, INTENG-21106*